### PR TITLE
backend-punto-entrada-addSubject-y-actualizar-vista

### DIFF
--- a/Ateneo-backend-Express/prisma/migrations/20241110002705_id_and_reset_password/migration.sql
+++ b/Ateneo-backend-Express/prisma/migrations/20241110002705_id_and_reset_password/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `professor` ADD COLUMN `resetPassword` DATETIME(3) NULL;

--- a/Ateneo-backend-Express/prisma/migrations/20241110003000_not_opcional_reset_password/migration.sql
+++ b/Ateneo-backend-Express/prisma/migrations/20241110003000_not_opcional_reset_password/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Made the column `resetPassword` on table `professor` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- AlterTable
+ALTER TABLE `professor` MODIFY `resetPassword` DATETIME(3) NOT NULL;

--- a/Ateneo-backend-Express/prisma/migrations/20241110033034_opcional_reset_password/migration.sql
+++ b/Ateneo-backend-Express/prisma/migrations/20241110033034_opcional_reset_password/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `professor` MODIFY `resetPassword` DATETIME(3) NULL;

--- a/Ateneo-backend-Express/prisma/schema.prisma
+++ b/Ateneo-backend-Express/prisma/schema.prisma
@@ -8,18 +8,18 @@ datasource db {
 }
 
 model Professor {
-  id             String    @id @default(uuid())
+  id             String    @id
   firstName      String
   lastName       String
   email          String    @unique
   password       String
-  // resetPassword  DateTime
+  resetPassword  DateTime?
   emailActivated Boolean
   subjects       Subject[]
 }
 
 model Student {
-  id            String         @id @default(uuid())
+  id            String         @id
   firstName     String
   lastName      String
   dni           BigInt         @unique
@@ -29,7 +29,7 @@ model Student {
 }
 
 model Class {
-  id        String    @id @default(uuid())
+  id        String    @id
   date      DateTime
   subject   Subject   @relation(fields: [subjectId], references: [id])
   subjectId String
@@ -37,7 +37,7 @@ model Class {
 }
 
 model Absence {
-  id        String  @id @default(uuid())
+  id        String  @id
   class     Class   @relation(fields: [classId], references: [id])
   classId   String
   student   Student @relation(fields: [studentId], references: [id])
@@ -46,7 +46,7 @@ model Absence {
 }
 
 model GradeRelationship {
-  id             String @id @default(uuid())
+  id             String @id
   weight         Float
   derivedGrade   Grade  @relation("DerivedGrade", fields: [derivedGradeId], references: [id])
   derivedGradeId String
@@ -55,7 +55,7 @@ model GradeRelationship {
 }
 
 model Subject {
-  id           String    @id @default(uuid())
+  id           String    @id
   name         String
   academicYear Int
   institution  String
@@ -67,7 +67,7 @@ model Subject {
 }
 
 model Grade {
-  id              String              @id @default(uuid())
+  id              String              @id
   name            String
   type            GradeType
   date            DateTime
@@ -80,7 +80,7 @@ model Grade {
 }
 
 model StudentGrade {
-  id        String  @id @default(uuid())
+  id        String  @id
   value     Float
   grade     Grade   @relation(fields: [gradeId], references: [id])
   gradeId   String

--- a/Ateneo-backend-Express/src/controllers/professor/login-professor-controller.ts
+++ b/Ateneo-backend-Express/src/controllers/professor/login-professor-controller.ts
@@ -10,10 +10,7 @@ export const LoginProfessorController = async (email: string, password: string):
         }
 
         return professor;
-    } catch (error: unknown) {
-        if (error instanceof Error) {
-            throw new Error(error.message);
-        }
-        throw new Error('Se produjo un error desconocido');
+    } catch (error: any) {
+        throw new Error(error.message);
     }
 };

--- a/Ateneo-backend-Express/src/controllers/professor/sign-up-professor-controller.ts
+++ b/Ateneo-backend-Express/src/controllers/professor/sign-up-professor-controller.ts
@@ -4,11 +4,8 @@ import bcrypt from 'bcrypt';
 export const SignUpProfessorController = async (email: string, password: string, firstName: string, lastName: string): Promise<string> => {
     try {
         password = await bcrypt.hash(password, 10);
-        return await SignUpProfessorHelper({ email, password, firstName, lastName });
-    } catch (error: unknown) {
-        if (error instanceof Error) {
-            throw new Error(error.message);
-        }
-        throw new Error('An unknown error occurred');
+        return await SignUpProfessorHelper(email, password, firstName, lastName);
+    } catch (error: any) {
+        throw new Error(error.message);
     }
 };

--- a/Ateneo-backend-Express/src/controllers/subject/add-subject-controller.ts
+++ b/Ateneo-backend-Express/src/controllers/subject/add-subject-controller.ts
@@ -1,0 +1,16 @@
+import { Subject } from '@prisma/client';
+import { addSubjectHelper } from '../../helpers/subject/add-subject-helper';
+
+export const AddSubjectController = async (
+    idProfessor: string,
+    academicYear: number,
+    name: string,
+    institution: string,
+    degree: string
+): Promise<string> => {
+    try {
+        return await addSubjectHelper(idProfessor, academicYear, name, institution, degree);
+    } catch (error: any) {
+        throw new Error(error.message);
+    }
+};

--- a/Ateneo-backend-Express/src/controllers/subject/get-all-subjects-controller.ts
+++ b/Ateneo-backend-Express/src/controllers/subject/get-all-subjects-controller.ts
@@ -4,10 +4,7 @@ import { GetAllSubjectsByIdProfessorHelper } from '../../helpers/subject/get-all
 export const GetAllSubjectsByIdProfessorController = async (idProfessor: string): Promise<Array<Subject>> => {
     try {
         return await GetAllSubjectsByIdProfessorHelper(idProfessor);
-    } catch (error: unknown) {
-        if (error instanceof Error) {
-            throw new Error(error.message);
-        }
-        throw new Error('An unknown error occurred');
+    } catch (error: any) {
+        throw new Error(error.message);
     }
 };

--- a/Ateneo-backend-Express/src/handlers/subject/add-subject-handler.ts
+++ b/Ateneo-backend-Express/src/handlers/subject/add-subject-handler.ts
@@ -1,0 +1,15 @@
+import { Request, Response } from 'express';
+import { AddSubjectController } from '../../controllers/subject/add-subject-controller';
+
+export const AddSubjectHandler = async (req: Request, res: Response): Promise<Response> => {
+    try {
+        const { idProfessor } = req.body;
+        const { academicYear, name, institution, degree } = req.body.subject;
+
+        const response = await AddSubjectController(idProfessor, academicYear, name, institution, degree);
+
+        return res.status(200).json({ message: response });
+    } catch (error: any) {
+        return res.status(500).json({ message: 'Error interno del servidor' });
+    }
+};

--- a/Ateneo-backend-Express/src/handlers/subject/get-all-subjects-handler.ts
+++ b/Ateneo-backend-Express/src/handlers/subject/get-all-subjects-handler.ts
@@ -1,8 +1,5 @@
 import { Request, Response } from 'express';
 import { GetAllSubjectsByIdProfessorController } from '../../controllers/subject/get-all-subjects-controller';
-import dotenv from 'dotenv';
-
-dotenv.config();
 
 export const GetAllSubjectsByIdProfessorHandler = async (req: Request, res: Response): Promise<Response> => {
     try {

--- a/Ateneo-backend-Express/src/helpers/professor/sign-up-professor-helper.ts
+++ b/Ateneo-backend-Express/src/helpers/professor/sign-up-professor-helper.ts
@@ -1,11 +1,12 @@
 import { PrismaClient, Professor } from '@prisma/client';
+import { generateId } from '../../utils/generate-id';
 
 const prisma = new PrismaClient();
 
-export const SignUpProfessorHelper = async (professor: Omit<Professor, 'id' | 'emailActivated'>): Promise<string> => {
+export const SignUpProfessorHelper = async (email: string, password: string, firstName: string, lastName: string): Promise<string> => {
     try {
         const existingProfessor = await prisma.professor.findUnique({
-            where: { email: professor.email }
+            where: { email: email }
         });
 
         if (existingProfessor) {
@@ -14,10 +15,11 @@ export const SignUpProfessorHelper = async (professor: Omit<Professor, 'id' | 'e
 
         await prisma.professor.create({
             data: {
-                email: professor.email,
-                firstName: professor.firstName,
-                lastName: professor.lastName,
-                password: professor.password,
+                id: generateId(),
+                email: email,
+                firstName: firstName,
+                lastName: lastName,
+                password: password,
                 emailActivated: true
             }
         });

--- a/Ateneo-backend-Express/src/helpers/subject/add-subject-helper.ts
+++ b/Ateneo-backend-Express/src/helpers/subject/add-subject-helper.ts
@@ -1,0 +1,27 @@
+import { PrismaClient } from '@prisma/client';
+import { generateId } from '../../utils/generate-id';
+
+const prisma = new PrismaClient();
+
+export const addSubjectHelper = async (idProfessor: string, academicYear: number, name: string, institution: string, degree: string) => {
+    try {
+        await prisma.subject.create({
+            data: {
+                id: generateId(),
+                name: name,
+                academicYear: academicYear,
+                institution: institution,
+                degree: degree,
+                professor: {
+                    connect: { id: idProfessor }
+                }
+            }
+        });
+
+        return 'Materia creada exitosamente';
+    } catch (error: unknown) {
+        throw new Error('Error al crear la materia');
+    } finally {
+        await prisma.$disconnect();
+    }
+};

--- a/Ateneo-backend-Express/src/routes/subject/index-subject-routes.ts
+++ b/Ateneo-backend-Express/src/routes/subject/index-subject-routes.ts
@@ -1,8 +1,10 @@
 import { Router } from 'express';
 import { GetAllSubjectsByIdProfessorHandler } from '../../handlers/subject/get-all-subjects-handler';
+import { AddSubjectHandler } from '../../handlers/subject/add-subject-handler';
 
 const subjectRouter = Router();
 
 subjectRouter.get('/professor/:idProfessor', GetAllSubjectsByIdProfessorHandler);
+subjectRouter.post('/professor/:idProfessor', AddSubjectHandler);
 
 export default subjectRouter;

--- a/Ateneo-backend-Express/src/utils/generate-id.ts
+++ b/Ateneo-backend-Express/src/utils/generate-id.ts
@@ -1,0 +1,10 @@
+export function generateId(): string {
+    // Extrae los últimos 4 dígitos del timestamp actual
+    const timestamp = Date.now().toString().slice(-4);
+
+    // Genera un número aleatorio de 4 dígitos y lo convierte a cadena con ceros al inicio si es necesario
+    const randomPart = String(Math.floor(Math.random() * 10000)).padStart(4, '0');
+
+    // Combina las dos partes para formar el ID
+    return `${timestamp}${randomPart}`;
+}

--- a/Ateneo-frontend-Angular/src/app/domain/use-cases/subject-use-cases/get-all-subjects-use-case.ts
+++ b/Ateneo-frontend-Angular/src/app/domain/use-cases/subject-use-cases/get-all-subjects-use-case.ts
@@ -1,6 +1,6 @@
 import { HttpClient } from '@angular/common/http';
 import { useCase } from '../use-case.interface';
-import { Observable } from 'rxjs';
+import { map, Observable } from 'rxjs';
 import { Injectable } from '@angular/core';
 import { Subject } from '../../entities/subject';
 
@@ -8,19 +8,17 @@ export interface IGetAllSubjectsParams {
     idProfessor: string;
 }
 
-export interface GetAllSubjectsResponse {
-    subjects: Array<Subject>;
-}
-
 @Injectable({
     providedIn: 'root'
 })
-export class GetAllSubjectsUseCase implements useCase<GetAllSubjectsResponse, IGetAllSubjectsParams> {
+export class GetAllSubjectsUseCase implements useCase<Array<Subject>, IGetAllSubjectsParams> {
     private BASE_URL = 'http://localhost:3001/subjects/professor';
 
     constructor(private httpClient: HttpClient) {}
 
-    execute(params: IGetAllSubjectsParams): Observable<GetAllSubjectsResponse> {
-        return this.httpClient.get<GetAllSubjectsResponse>(`${this.BASE_URL}/${params.idProfessor}`);
+    execute(params: IGetAllSubjectsParams): Observable<Array<Subject>> {
+        return this.httpClient
+            .get<{ subjects: Array<Subject> }>(`${this.BASE_URL}/${params.idProfessor}`)
+            .pipe(map((response) => response.subjects));
     }
 }

--- a/Ateneo-frontend-Angular/src/app/ui/pages/dashboard/subjects/subjects.component.html
+++ b/Ateneo-frontend-Angular/src/app/ui/pages/dashboard/subjects/subjects.component.html
@@ -36,7 +36,7 @@
             </div>
 
             <app-submit [withText]="!addSubjectLoading" [loading]="addSubjectLoading" [disabled]="subjectForm.invalid">
-                Iniciar Sesión
+                Agregar materia
             </app-submit>
         </form>
     </div>

--- a/Ateneo-frontend-Angular/src/app/ui/pages/dashboard/subjects/subjects.component.scss
+++ b/Ateneo-frontend-Angular/src/app/ui/pages/dashboard/subjects/subjects.component.scss
@@ -70,6 +70,7 @@ mat-card {
     border: 1px solid $grey-white-color;
     background-color: $primary-color;
     color: $white-color;
+    gap: 10px;
 }
 
 .mat-card-text {
@@ -82,7 +83,6 @@ mat-card {
 
 .subject-card {
     width: 250px;
-    height: 100px;
     transition:
         box-shadow 0.3s ease,
         border-color 0.3s ease;
@@ -108,7 +108,6 @@ mat-card {
 @media (max-width: 600px) {
     .subject-card {
         width: 200px;
-        height: 90px;
     }
 
     .mat-form-field-container {
@@ -120,11 +119,5 @@ mat-card {
         mat-error {
             margin-bottom: 10px;
         }
-    }
-}
-
-@media (max-width: 360px) {
-    .subject-card {
-        height: 80px;
     }
 }

--- a/Ateneo-frontend-Angular/src/app/ui/pages/dashboard/subjects/subjects.component.ts
+++ b/Ateneo-frontend-Angular/src/app/ui/pages/dashboard/subjects/subjects.component.ts
@@ -30,7 +30,10 @@ export class SubjectsComponent implements OnInit {
             degree: ['', Validators.required],
             academicYear: ['', [Validators.required, this.academicYearValidator]]
         });
+        this.getAllSubjects();
+    }
 
+    private getAllSubjects(): void {
         this.subjectsViewModel.getAllSubjects().subscribe(
             (subjects) => {
                 this.subjects = subjects;
@@ -41,6 +44,7 @@ export class SubjectsComponent implements OnInit {
             }
         );
     }
+
     public academicYearValidator(control: AbstractControl): ValidationErrors | null {
         const year = control.value;
 
@@ -73,16 +77,18 @@ export class SubjectsComponent implements OnInit {
         const newSubject = this.subjectForm.value as Subject;
 
         this.subjectsViewModel.addSubject(newSubject).subscribe(
-            (subject) => {
-                this.subjects.push(subject);
+            (success) => {
+                this.notifyService.notify(success.message, 'success-notify');
+                this.addSubjectLoading = false;
                 this.subjectForm.reset();
                 this.showForm = false;
-                this.addSubjectLoading = false;
+                this.getAllSubjects();
             },
             (error) => {
                 this.notifyService.notify(error.error.message, 'error-notify', 'Cerrar');
-                this.showForm = false;
                 this.addSubjectLoading = false;
+                this.subjectForm.reset();
+                this.showForm = false;
                 throw error.error.message;
             }
         );

--- a/Ateneo-frontend-Angular/src/app/ui/pages/dashboard/subjects/subjectsViewModel.service.ts
+++ b/Ateneo-frontend-Angular/src/app/ui/pages/dashboard/subjects/subjectsViewModel.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { GetAllSubjectsUseCase, GetAllSubjectsResponse } from '../../../../domain/use-cases/subject-use-cases/get-all-subjects-use-case';
+import { GetAllSubjectsUseCase } from '../../../../domain/use-cases/subject-use-cases/get-all-subjects-use-case';
 import { TokenService } from '../../../shared/services/token.service';
 import { Observable, throwError } from 'rxjs';
 import { map } from 'rxjs/operators';
@@ -22,9 +22,7 @@ export class SubjectsViewModelService {
     }
 
     public getAllSubjects(): Observable<Array<Subject>> {
-        return this.getAllSubjectsUseCase
-            .execute({ idProfessor: this.professorId! })
-            .pipe(map((response: GetAllSubjectsResponse) => response.subjects));
+        return this.getAllSubjectsUseCase.execute({ idProfessor: this.professorId! });
     }
 
     public addSubject(subject: Subject): Observable<any> {

--- a/Ateneo-frontend-Angular/src/app/ui/pages/sign-up/sign-up.component.ts
+++ b/Ateneo-frontend-Angular/src/app/ui/pages/sign-up/sign-up.component.ts
@@ -6,6 +6,7 @@ import { SignUpViewModelService } from './sign-up-view-model.service';
 import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
 import { NotifyService } from '../../shared/services/notify.service';
 import { sha256 } from 'js-sha256';
+import { TokenService } from '../../shared/services/token.service';
 
 @Component({
     selector: 'app-sign-up',
@@ -22,10 +23,15 @@ export class SignUpComponent implements OnInit {
         private router: Router,
         private resolutionService: ResolutionService,
         private signUpViewModelService: SignUpViewModelService,
-        private notifyService: NotifyService
+        private notifyService: NotifyService,
+        private tokenService: TokenService
     ) {}
 
     public ngOnInit(): void {
+        if (this.tokenService.getUserFromToken() !== null) {
+            this.router.navigate(['/dashboard/subjects']);
+        }
+
         this.signUpForm = this.fb.group({
             firstName: ['', [Validators.required]],
             lastName: ['', [Validators.required]],

--- a/Ateneo-frontend-Angular/src/app/ui/pages/sign-up/sign-up.component.ts
+++ b/Ateneo-frontend-Angular/src/app/ui/pages/sign-up/sign-up.component.ts
@@ -29,6 +29,7 @@ export class SignUpComponent implements OnInit {
 
     public ngOnInit(): void {
         if (this.tokenService.getUserFromToken() !== null) {
+            this.notifyService.notify('Si quieres crear una cuenta, cierra la sesión activa', 'info-notify', 'Cerrar');
             this.router.navigate(['/dashboard/subjects']);
         }
 

--- a/Ateneo-frontend-Angular/src/app/ui/shared/services/notify.service.ts
+++ b/Ateneo-frontend-Angular/src/app/ui/shared/services/notify.service.ts
@@ -24,7 +24,7 @@ export class NotifyService {
 
         this.zone.run((): void => {
             this.snackBar.open(notification, button, {
-                duration: duration * 100000,
+                duration: duration * 1000,
                 verticalPosition: 'top',
                 horizontalPosition: 'right',
                 panelClass: [severity]


### PR DESCRIPTION
Se completó el agregado de materia y su posterior actualización en el frontend, se actualizó para que resetPassword pueda ser null si todavía no lo pediste o no está activo, los id ahora se generan a partir de una función que utiliza el momento de creación (4 cifras) y un número aleatorio de 4 cifras, y ahora no se puede registrar a alguien con la sesión iniciada